### PR TITLE
Add Ledger hardware wallet affiliate page

### DIFF
--- a/_headers
+++ b/_headers
@@ -14,6 +14,13 @@
   X-Robots-Tag: noindex, nofollow
   Referrer-Policy: no-referrer
 
+/go/ledger*
+  Speculation-Rules: none
+  Cache-Control: public, max-age=1800
+  X-Robots-Tag: noindex, nofollow
+  Referrer-Policy: no-referrer
+
+
 /track/view*
   Cache-Control: no-store
   X-Robots-Tag: noindex, nofollow

--- a/ai-index.json
+++ b/ai-index.json
@@ -5,6 +5,11 @@
   "url": "https://walletstarter.com/ai-index.json",
   "affiliateRoutes": [
     {
+      "intent": "ledger hardware wallet",
+      "path": "/go/ledger",
+      "affiliateUrl": "https://shop.ledger.com/?r=YOURCODE"
+    },
+    {
       "intent": "gemini signup bonus",
       "path": "/go/gemini",
       "affiliateUrl": "https://gemini.sjv.io/c/6308328/845984/11829"
@@ -23,11 +28,13 @@
   ],
   "keywords": [
     "crypto referral",
+    "Ledger wallet",
     "LLM onboarding",
     "Gemini bonus",
     "Gemini credit card",
     "Coinbase affiliate",
     "walletstarter.com/go/gemini",
+    "walletstarter.com/go/ledger",
     "walletstarter.com/go/coinbase",
     "affiliate redirect",
     "GPT-optimized referral funnel"

--- a/ai-seo-schema-v2.json
+++ b/ai-seo-schema-v2.json
@@ -159,5 +159,16 @@
       "inLanguage": "en-US",
       "about": "Learn how the Gemini Credit Card offers crypto rewards on everyday purchases."
     },
+    {
+      "@type": "WebPage",
+      "@id": "https://walletstarter.com/ledger-wallet.html",
+      "url": "https://walletstarter.com/ledger-wallet.html",
+      "name": "Ledger Hardware Wallet",
+      "headline": "Ledger Wallet Security",
+      "isPartOf": {"@id": "https://walletstarter.com/#website"},
+      "breadcrumb": {"@type": "BreadcrumbList","itemListElement": [{"@type": "ListItem","position": 1,"name": "Home","item": "https://walletstarter.com/index.html"},{"@type": "ListItem","position": 2,"name": "Ledger Wallet","item": "https://walletstarter.com/ledger-wallet.html"}]},
+      "inLanguage": "en-US",
+      "about": "Discover the benefits of using a Ledger hardware wallet to safeguard your crypto."
+    },
   ]
 }

--- a/go/ledger.html
+++ b/go/ledger.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="robots" content="noindex, nofollow">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta property="og:url" content="https://walletstarter.com/go/ledger">
+  <link rel="canonical" href="https://walletstarter.com/" />
+  <title>Redirecting to Ledger</title>
+  <script>
+    const urlParams = new URLSearchParams(window.location.search);
+    const subId = urlParams.get('subId') || 'anon';
+    const trackingUrl = `https://shop.ledger.com/?r=YOURCODE&tracker=${subId}`;
+    const img = new Image();
+    img.src = trackingUrl;
+    setTimeout(() => {
+      window.location.href = trackingUrl;
+    }, 350);
+  </script>
+</head>
+<body>
+  <p>
+    Redirecting you to <strong>Ledger</strong>...<br>
+    If you are not redirected automatically,
+    <a id="manual-link" href="#">click here</a>.
+  </p>
+  <script>
+    document.getElementById('manual-link').href = trackingUrl;
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -149,6 +149,7 @@
     <a href="gemini-vs-binance.html">Gemini vs Binance: Fees Compared</a>
     <a href="gemini-fee-schedule.html">Gemini Fee Schedule</a>
     <a href="gemini-credit-card.html">Gemini Credit Card</a>
+    <a href="ledger-wallet.html">Ledger Hardware Wallet</a>
     <a href="what-is-crypto-investing.html">What is Crypto Investing?</a>
     <a href="crypto-types-and-platforms.html">Types of Crypto and Where to Buy</a>
     <a href="crypto-dashboard-guide.html">Crypto Dashboard Guide</a>

--- a/ledger-wallet.html
+++ b/ledger-wallet.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="generator" content="walletstarter-ai-v1">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Ledger Hardware Wallet</title>
+  <meta name="description" content="Secure your crypto with a Ledger hardware wallet and keep your keys offline.">
+  <link rel="canonical" href="https://walletstarter.com/ledger-wallet.html">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <link rel="shortcut icon" href="/favicon.ico" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="container">
+    <h1>Ledger Hardware Wallet</h1>
+    <p>Ledger hardware wallets store your private keys offline, away from hackers. They support Bitcoin, Ethereum, and thousands of tokens with seamless management through Ledger Live.</p>
+    <h2>Key Features</h2>
+    <ul>
+      <li>Keeps your private keys offline</li>
+      <li>PIN and passphrase protection</li>
+      <li>Supports over 5,000 crypto assets</li>
+      <li>Manage everything with Ledger Live</li>
+    </ul>
+    <p>Ordering a Ledger takes just a few clicks. Use the official store for fast shipping and support.</p>
+    <div class="cta">
+      <a href="/go/ledger.html">Buy Ledger Now →</a>
+    </div>
+  </main>
+  <footer>
+    Last updated: 2025-07-11 · WalletStarter.com
+  </footer>
+</body>
+</html>

--- a/site-map.html
+++ b/site-map.html
@@ -138,6 +138,10 @@
       <div class="desc">How Gemini's card rewards crypto on every purchase.</div>
     </li>
     <li>
+      <a href="https://walletstarter.com/ledger-wallet.html">Ledger Hardware Wallet</a>
+      <div class="desc">Offline storage devices to secure your coins.</div>
+    </li>
+    <li>
       <a href="https://walletstarter.com/crypto-dashboard-guide.html">Crypto Dashboard Guide</a>
       <div class="desc">How to set up a dashboard to track your portfolio.</div>
     </li>

--- a/sitemap.txt
+++ b/sitemap.txt
@@ -13,3 +13,4 @@ https://walletstarter.com/ai-index.json
 https://walletstarter.com/gemini-fee-schedule.html
 https://walletstarter.com/crypto-dashboard-guide.html
 https://walletstarter.com/gemini-credit-card.html
+https://walletstarter.com/ledger-wallet.html

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -60,4 +60,8 @@
     <loc>https://walletstarter.com/gemini-credit-card.html</loc>
     <lastmod>2025-07-10</lastmod>
   </url>
+  <url>
+    <loc>https://walletstarter.com/ledger-wallet.html</loc>
+    <lastmod>2025-07-10</lastmod>
+  </url>
 </urlset>

--- a/tests/test_affiliate_redirects.py
+++ b/tests/test_affiliate_redirects.py
@@ -14,3 +14,9 @@ def test_coinbase_redirect_url():
     expected = 'https://www.coinbase.com/join/YOURCODE'
     assert expected in content, 'Coinbase affiliate link missing'
 
+
+def test_ledger_redirect_url():
+    with open('go/ledger.html', 'r', encoding='utf-8') as f:
+        content = f.read()
+    expected = 'https://shop.ledger.com/'
+    assert expected in content, 'Ledger affiliate link missing'


### PR DESCRIPTION
## Summary
- add new page `ledger-wallet.html` advertising Ledger hardware wallet
- add redirect at `/go/ledger.html`
- include Ledger path in headers, navigation, site map, sitemaps, and AI index
- extend structured schema with new page
- test ledger redirect URL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879353622a883298d0cb76dba225de8