### PR TITLE
Update homepage gif display

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,8 +136,8 @@
   <div class="hero">
     <video autoplay loop muted playsinline width="100%" style="max-height: 400px; object-fit: cover; border-radius: 12px; box-shadow: 0 10px 30px rgba(0,0,0,0.4);">
       <source src="img/hard-wallet-animation.webm" type="video/webm">
-      <img src="img/hard-wallet-animation.gif" alt="Hard Wallet Animation" width="720" height="405" loading="lazy">
-    </video>
+      <img src="img/hard-wallet-animation.gif.gif?raw=1" alt="Hard Wallet Animation" width="720" height="405" loading="lazy">
+      </video>
   </div>
 
   <section class="intro container">


### PR DESCRIPTION
## Summary
- switch homepage fallback GIF to `hard-wallet-animation.gif.gif`
- ensure GitHub renders the GIF by adding `?raw=1` to the image URL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a643641b88329813e723c871a6583