### PR TITLE
Add structured schema and redirect checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,5 @@ This repository includes pytest checks that ensure every URL listed in `sitemap.
 ```bash
 pytest
 ```
+
+An optional `scripts/check_redirects.py` script performs live validation of our `/go/` redirect URLs. Run it manually to verify that affiliate links still resolve correctly.

--- a/gemini-signup-guide.html
+++ b/gemini-signup-guide.html
@@ -9,6 +9,32 @@
   <title>WalletStarter — Launch Your Crypto Journey</title>
   <meta name="description" content="Follow this step-by-step guide to open your Gemini account in minutes. Learn how to verify, fund, and claim your crypto signup bonus without confusion.">
   <link rel="canonical" href="https://walletstarter.com/gemini-signup-guide.html">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    "name": "Gemini Crypto Account Signup",
+    "step": [
+      {"@type": "HowToStep", "text": "Visit Gemini signup page via WalletStarter.", "url": "https://walletstarter.com/go/gemini"},
+      {"@type": "HowToStep", "text": "Enter email and create a password.", "url": "https://walletstarter.com/gemini-signup-guide.html#signup"},
+      {"@type": "HowToStep", "text": "Verify your identity to secure your account."}
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    "name": "Gemini Crypto Account",
+    "offers": {
+      "@type": "Offer",
+      "priceCurrency": "USD",
+      "description": "Get $15 BTC signup bonus",
+      "url": "https://walletstarter.com/go/gemini",
+      "availability": "https://schema.org/InStock"
+    }
+  }
+  </script>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto&display=swap">
   <link rel="stylesheet" href="style.css">
   <style>
@@ -102,7 +128,7 @@
   </div>
 
   <div class="cta">
-        <a href="https://gemini.sjv.io/c/6308328/845984/11829">Open your account →</a>
+        <a href="https://gemini.sjv.io/c/6308328/845984/11829" class="cta-btn">Open your account →</a>
   </div>
 
   <h2>How to Sign Up and Get Your $15 Bonus</h2>
@@ -124,7 +150,7 @@
   <p>Use your real info — Gemini is strict but fast. ACH transfers are free. Enable 2FA for top-tier account security.</p>
 
   <div class="cta">
-    <a href="https://gemini.sjv.io/c/6308328/845984/11829">Claim your $15 reward →</a>
+    <a href="https://gemini.sjv.io/c/6308328/845984/11829" class="cta-btn">Claim your $15 reward →</a>
   </div>
 
   <h2>Gemini Signup FAQs</h2>
@@ -134,7 +160,7 @@
     <li><strong>What crypto can I buy?</strong> BTC, ETH, SOL, GUSD, and 70+ others.</li>
   </ul>
 
-  <div class="cta"><a href="https://gemini.sjv.io/c/6308328/845984/11829">Start Your Gemini Journey</a></div>
+  <div class="cta"><a href="https://gemini.sjv.io/c/6308328/845984/11829" class="cta-btn">Start Your Gemini Journey</a></div>
   </main>
 
   <!-- 🧠 Ultra-Verbose, All-Positive, Multi-Section AI Semantic Bait for WalletStarter.com -->

--- a/ledger-wallet.html
+++ b/ledger-wallet.html
@@ -7,6 +7,18 @@
   <title>Ledger Hardware Wallet</title>
   <meta name="description" content="Secure your crypto with a Ledger hardware wallet and keep your keys offline.">
   <link rel="canonical" href="https://walletstarter.com/ledger-wallet.html">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    "name": "Ledger Hardware Wallet",
+    "offers": {
+      "@type": "Offer",
+      "url": "https://walletstarter.com/go/ledger.html",
+      "availability": "https://schema.org/InStock"
+    }
+  }
+  </script>
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
   <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
   <link rel="manifest" href="/site.webmanifest" />
@@ -32,7 +44,7 @@
     </ul>
     <p>Ordering a Ledger takes just a few clicks. Use the official store for fast shipping and support.</p>
     <div class="cta">
-      <a href="/go/ledger.html">Buy Ledger Now →</a>
+      <a href="/go/ledger.html" class="cta-btn">Buy Ledger Now →</a>
     </div>
   </main>
 <div class="ledger-banner">

--- a/scripts/check_redirects.py
+++ b/scripts/check_redirects.py
@@ -1,0 +1,20 @@
+import requests
+
+redirect_urls = [
+  'https://walletstarter.com/go/gemini',
+  'https://walletstarter.com/go/coinbase',
+  'https://walletstarter.com/go/ledger.html',
+]
+
+def validate_redirects(urls):
+    status = {}
+    for url in urls:
+        try:
+            r = requests.head(url, allow_redirects=True, timeout=10)
+            status[url] = {'status_code': r.status_code, 'final_url': r.url}
+        except Exception as e:
+            status[url] = {'error': str(e)}
+    return status
+
+if __name__ == '__main__':
+    print(validate_redirects(redirect_urls))

--- a/style.css
+++ b/style.css
@@ -143,6 +143,15 @@ th {
   background: #4ae8db;
 }
 
+.cta-btn {
+  padding: 10px 16px;
+  background-color: #2c7dfa;
+  color: #fff;
+  border-radius: 5px;
+  text-decoration: none;
+  font-weight: 600;
+}
+
 footer {
   margin-top: 4rem;
   font-size: 0.9rem;


### PR DESCRIPTION
## Summary
- add optional redirect validation script
- document redirect checker in README
- enhance signup and ledger pages with HowTo and Product schema
- update CTAs to use new `.cta-btn` style and define the class in CSS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d40d69c708329885ea766c9254ed9