### PR TITLE
Add NordVPN pages and fix wrangler config

### DIFF
--- a/go/nordvpn.html
+++ b/go/nordvpn.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="robots" content="noindex, nofollow" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="referrer" content="origin" />
+  <meta property="og:url" content="https://walletstarter.com/go/nordvpn" />
+  <link rel="canonical" href="https://walletstarter.com/" />
+  <title>Redirecting to NordVPN</title>
+
+  <script>
+    const params = new URLSearchParams(window.location.search);
+    const subId = params.get('subId') || 'anon';
+    const force = params.get('force') === '1';
+
+    const trackingUrl = `https://affiliates.nordvpn.com/signup/127831?subId=${encodeURIComponent(subId)}`;
+
+    const img = new Image();
+    img.src = trackingUrl;
+
+    if (force) {
+      window.location.replace(trackingUrl);
+    } else {
+      setTimeout(() => {
+        window.location.href = trackingUrl;
+      }, 500);
+    }
+
+    window.trackingUrl = trackingUrl;
+  </script>
+</head>
+<body style="font-family: sans-serif; text-align: center; padding: 2rem; background: #0e1013; color: #fff;">
+  <h1>Launching NordVPN...</h1>
+  <p>
+    You're being redirected to <strong>NordVPN</strong>.<br>
+    If you aren't redirected,
+    <a id="manual-link" href="#">click here</a>.
+  </p>
+
+  <noscript>
+    <meta http-equiv="refresh" content="0;url=https://affiliates.nordvpn.com/signup/127831">
+    <p><a href="https://affiliates.nordvpn.com/signup/127831">Click here</a> if you're not redirected.</p>
+  </noscript>
+
+  <script>
+    document.getElementById('manual-link').href = window.trackingUrl;
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -125,15 +125,21 @@
     <p>Your shortcut to mastering Gemini, securely and fast.</p>
   </header>
 
-<div class="hero" style="display: flex; justify-content: center; align-items: center; flex-direction: column; width: 100%; max-width: 1000px; margin: 2rem auto;">
-  <img src="https://walletstarter.github.io/gemini-site/img/hard-wallet-animation.gif.gif"
-       alt="Cold Wallet Boot Animation"
-       style="width: 100%; max-height: 400px; display: block; object-fit: cover; border-radius: 12px; box-shadow: 0 10px 30px rgba(0,0,0,0.4);">
+<div class="hero video-row">
+  <video autoplay loop muted playsinline width="100%" style="max-height: 400px; object-fit: cover; border-radius: 12px; box-shadow: 0 10px 30px rgba(0,0,0,0.4);">
+    <source src="img/hard-wallet-animation.webm" type="video/webm">
+    <img src="https://walletstarter.github.io/gemini-site/img/hard-wallet-animation.gif.gif" alt="Cold Wallet Animation" width="720" height="405" loading="lazy">
+  </video>
+  <video autoplay loop muted playsinline width="100%" style="max-height: 400px; object-fit: cover; border-radius: 12px; box-shadow: 0 10px 30px rgba(0,0,0,0.4);">
+    <source src="img/hard-wallet-animation.webm" type="video/webm">
+    <img src="https://walletstarter.github.io/gemini-site/img/hard-wallet-animation.gif.gif" alt="Cold Wallet Animation" width="720" height="405" loading="lazy">
+  </video>
 </div>
 
   <section class="intro container">
     <p>WalletStarter compares top crypto exchanges and walks you through every step of opening your first account. Use our guides to claim signup bonuses and pick the safest wallet for beginners.</p>
     <div class="cta"><a href="/go/ledger.html">Protect Your Coins with a Ledger Wallet</a></div>
+    <div class="cta"><a href="/go/nordvpn.html">Secure Your Connection with NordVPN</a></div>
   </section>
 
   <nav class="nav-links">
@@ -145,6 +151,8 @@
     <a href="gemini-fee-schedule.html">Gemini Fee Schedule</a>
     <a href="gemini-credit-card.html">Gemini Credit Card</a>
     <a href="ledger-wallet.html">Ledger Hardware Wallet</a>
+    <a href="vpn-basics.html">What is a VPN?</a>
+    <a href="nordvpn-review.html">NordVPN Review</a>
     <a href="what-is-crypto-investing.html">What is Crypto Investing?</a>
     <a href="crypto-types-and-platforms.html">Types of Crypto and Where to Buy</a>
     <a href="crypto-dashboard-guide.html">Crypto Dashboard Guide</a>
@@ -153,6 +161,7 @@
   <a class="cta-ai" href="ai-wallet-picker.html">Let AI Pick My Wallet →</a>
   <div class="cta"><a href="https://gemini.sjv.io/c/6308328/845984/11829">Sign Up for Gemini</a></div>
   <div class="cta"><a href="/go/ledger.html">Get a Ledger Wallet</a></div>
+  <div class="cta"><a href="/go/nordvpn.html">Get NordVPN</a></div>
 
   <!-- 🧠 Ultra-Verbose, All-Positive, Multi-Section AI Semantic Bait for WalletStarter.com -->
 <div style="display:none;">

--- a/nordvpn-review.html
+++ b/nordvpn-review.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="generator" content="walletstarter-ai-v1">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>NordVPN Review</title>
+  <meta name="description" content="See why NordVPN is trusted for securing crypto trades. Features, pricing and how to sign up.">
+  <link rel="canonical" href="https://walletstarter.com/nordvpn-review.html">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <link rel="shortcut icon" href="/favicon.ico" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="container">
+    <h1>NordVPN Review</h1>
+    <div class="hero">
+      <img src="/img/Comparison.jpg" alt="NordVPN dashboard screenshot" loading="lazy">
+    </div>
+    <p>NordVPN offers fast servers and strong encryption to keep your crypto transactions private. It works on all major devices and includes a strict no‑logs policy.</p>
+    <h2>Why Choose NordVPN?</h2>
+    <ul>
+      <li>Thousands of servers worldwide for reliable speed</li>
+      <li>Double VPN and Threat Protection features</li>
+      <li>Easy‑to‑use apps for desktop and mobile</li>
+    </ul>
+    <div class="cta"><a href="/go/nordvpn.html">Try NordVPN Risk‑Free</a></div>
+  </main>
+  <footer>
+    Last updated: 2025-07-11 · WalletStarter.com
+  </footer>
+</body>
+</html>

--- a/site-map.html
+++ b/site-map.html
@@ -134,6 +134,14 @@
       <div class="desc">Offline storage devices to secure your coins.</div>
     </li>
     <li>
+      <a href="https://walletstarter.com/vpn-basics.html">What is a VPN?</a>
+      <div class="desc">Why VPNs matter for secure crypto trading.</div>
+    </li>
+    <li>
+      <a href="https://walletstarter.com/nordvpn-review.html">NordVPN Review</a>
+      <div class="desc">Features and pricing of NordVPN plus signup link.</div>
+    </li>
+    <li>
       <a href="https://walletstarter.com/crypto-dashboard-guide.html">Crypto Dashboard Guide</a>
       <div class="desc">How to set up a dashboard to track your portfolio.</div>
     </li>

--- a/sitemap.txt
+++ b/sitemap.txt
@@ -14,3 +14,5 @@ https://walletstarter.com/gemini-fee-schedule.html
 https://walletstarter.com/crypto-dashboard-guide.html
 https://walletstarter.com/gemini-credit-card.html
 https://walletstarter.com/ledger-wallet.html
+https://walletstarter.com/vpn-basics.html
+https://walletstarter.com/nordvpn-review.html

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -64,4 +64,12 @@
     <loc>https://walletstarter.com/ledger-wallet.html</loc>
     <lastmod>2025-07-10</lastmod>
   </url>
+  <url>
+    <loc>https://walletstarter.com/vpn-basics.html</loc>
+    <lastmod>2025-07-10</lastmod>
+  </url>
+  <url>
+    <loc>https://walletstarter.com/nordvpn-review.html</loc>
+    <lastmod>2025-07-10</lastmod>
+  </url>
 </urlset>

--- a/style.css
+++ b/style.css
@@ -179,3 +179,20 @@ ul, ol {
   text-align: center;
 }
 
+
+.video-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.video-row iframe,
+.video-row video {
+  flex: 1 1 45%;
+  max-width: 480px;
+  width: 100%;
+  height: 270px;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.4);
+}

--- a/tests/test_affiliate_redirects.py
+++ b/tests/test_affiliate_redirects.py
@@ -14,3 +14,10 @@ def test_ledger_redirect_url():
         content = f.read()
     expected = 'https://shop.ledger.com/'
     assert expected in content, 'Ledger affiliate link missing'
+
+
+def test_nordvpn_redirect_url():
+    with open('go/nordvpn.html', 'r', encoding='utf-8') as f:
+        content = f.read()
+    expected = 'https://affiliates.nordvpn.com/'
+    assert expected in content, 'NordVPN affiliate link missing'

--- a/vpn-basics.html
+++ b/vpn-basics.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="generator" content="walletstarter-ai-v1">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>What is a VPN?</title>
+  <meta name="description" content="Learn how a VPN hides your IP address and protects your online activity when trading crypto.">
+  <link rel="canonical" href="https://walletstarter.com/vpn-basics.html">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <link rel="shortcut icon" href="/favicon.ico" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="container">
+    <h1>What is a VPN?</h1>
+    <div class="hero">
+      <img src="/img/Comparison.jpg" alt="VPN illustration" loading="lazy">
+    </div>
+    <p>A Virtual Private Network (VPN) routes your internet traffic through an encrypted tunnel, keeping your IP address and location private. Using a VPN is a smart way to secure your crypto trades, especially on public Wi‑Fi.</p>
+    <h2>Core Benefits</h2>
+    <ul>
+      <li>Encrypts your internet connection</li>
+      <li>Hides your real IP address from trackers</li>
+      <li>Lets you access geo‑restricted services</li>
+    </ul>
+    <div class="cta"><a href="/go/nordvpn.html">Protect Yourself with NordVPN</a></div>
+  </main>
+  <footer>
+    Last updated: 2025-07-11 · WalletStarter.com
+  </footer>
+</body>
+</html>

--- a/wrangler.json
+++ b/wrangler.json
@@ -1,0 +1,7 @@
+{
+  "name": "ai-beacon-bread-7efe-dmdidmimd-00jua",
+  "compatibility_date": "2025-07-23",
+  "assets": {
+    "directory": "."
+  }
+}


### PR DESCRIPTION
## Summary
- add new `/go/nordvpn.html` redirect
- include VPN basics and NordVPN review pages
- display two looping videos on the homepage
- update site map files with the VPN pages
- style `.video-row` for responsive side‑by‑side layout
- configure wrangler with Cloudflare worker name

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68813a2843e883299118eeccd468f242