### PR TITLE
Improve caching for affiliate redirects

### DIFF
--- a/_headers
+++ b/_headers
@@ -10,13 +10,20 @@
 
 /go/gemini*
   Speculation-Rules: none
-  Cache-Control: public, max-age=1800
+  Cache-Control: public, max-age=31536000, immutable
+  X-Robots-Tag: noindex, nofollow
+  Referrer-Policy: no-referrer
+ 
+/go/nordvpn*
+  Speculation-Rules: none
+  Cache-Control: public, max-age=31536000, immutable
   X-Robots-Tag: noindex, nofollow
   Referrer-Policy: no-referrer
 
+
 /go/ledger*
   Speculation-Rules: none
-  Cache-Control: public, max-age=1800
+  Cache-Control: public, max-age=31536000, immutable
   X-Robots-Tag: noindex, nofollow
   Referrer-Policy: no-referrer
 


### PR DESCRIPTION
## Summary
- add `.nojekyll` to disable Jekyll processing on GitHub Pages
- extend caching for `/go/gemini*`, `/go/nordvpn*`, and `/go/ledger*`
- add headers for new NordVPN redirect path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68839d93ccf88329841ffa567d4ac2e9