### PR TITLE
Restyle ad banner for cohesive crypto aesthetic

### DIFF
--- a/ads.css
+++ b/ads.css
@@ -1,6 +1,6 @@
 .promo-bar,.mobile-cta{
   font:14px/1.4 system-ui,sans-serif;
-  background:#f2f2f2;color:#222;
+  background:#1f232a;color:#e6e6e6;
   padding:8px 16px;
   display:flex;align-items:center;justify-content:space-between;gap:8px;
 }
@@ -8,21 +8,21 @@
 .promo-bar button.close{background:none;border:0;font-size:20px;line-height:1;color:inherit;cursor:pointer}
 .mobile-cta{position:fixed;bottom:0;left:0;right:0;z-index:998;display:none}
 .mobile-cta .btn,.promo-bar .btn,.aff-card .btn{
-  background:#0070f3;color:#fff;text-decoration:none;
+  background:#66fcf1;color:#0b0c10;text-decoration:none;
   padding:6px 12px;border-radius:4px;white-space:nowrap
 }
 @media(max-width:768px){.mobile-cta{display:flex}}
 body.has-promo-bar{padding-top:40px}
 body.has-mobile-cta{padding-bottom:56px}
 .aff-card{
-  border:1px solid #ccc;padding:16px;border-radius:6px;margin:16px 0;
-  font:14px/1.4 system-ui,sans-serif
+  border:1px solid #2c2c2c;padding:16px;border-radius:6px;margin:16px 0;
+  font:14px/1.4 system-ui,sans-serif;background:#1f232a;color:#e6e6e6
 }
 .aff-card h3{margin-top:0;font-size:16px}
 .aff-card ul{margin:8px 0 0;padding-left:20px}
 .sidebar .aff-card{margin-top:16px}
-.ad-variant-b .promo-bar,.ad-variant-b .mobile-cta{background:#ffe08a}
-@media(prefers-color-scheme:dark){
-  .promo-bar,.mobile-cta,.aff-card{background:#333;color:#fff;border-color:#555}
-  .ad-variant-b .promo-bar,.ad-variant-b .mobile-cta{background:#665200}
+.ad-variant-b .promo-bar,.ad-variant-b .mobile-cta{background:#0a0d12}
+@media(prefers-color-scheme:light){
+  .promo-bar,.mobile-cta,.aff-card{background:#f2f2f2;color:#222;border-color:#ccc}
+  .ad-variant-b .promo-bar,.ad-variant-b .mobile-cta{background:#e0e0e0}
 }

--- a/index.html
+++ b/index.html
@@ -206,12 +206,12 @@
   </section>
 
   <style>
-  .luxury-destinations{background:#f6f7fb;padding:2rem;margin:2rem 0;border-radius:10px;text-align:center}
+  .luxury-destinations{background:#0a0d12;padding:2rem;margin:2rem 0;border-radius:10px;text-align:center;border:1px solid #66fcf1}
   .luxury-destinations h2{margin:0 0 .5rem 0}
   .luxury-destinations p{margin:.25rem 0 1.25rem 0}
   .button-grid{display:flex;gap:12px;justify-content:center;flex-wrap:wrap}
-  .lux-btn{display:inline-block;padding:.7rem 1.1rem;border-radius:6px;background:#0b5fff;color:#fff;text-decoration:none;font-weight:600}
-  .lux-btn:hover{background:#084ad6}
+  .lux-btn{display:inline-block;padding:.7rem 1.1rem;border-radius:6px;background:#0a0d12;color:#66fcf1;text-decoration:none;font-weight:600;border:1px solid #66fcf1;transition:background .2s ease}
+  .lux-btn:hover{background:#66fcf1;color:#0b0c10}
   </style>
   <nav class="nav-links">
     <a href="gemini-signup-guide.html">Gemini Signup Guide</a>


### PR DESCRIPTION
## Summary
- Align promo bar and mobile CTA with site's dark color palette for less distracting ads
- Use turquoise buttons and subtle borders so affiliate cards blend with surrounding theme
- Bring luxury destination section into same dark scheme with turquoise accents

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b7102acac83299c2a57f0f90385db